### PR TITLE
Reorder return json to improve debugging

### DIFF
--- a/src/main/resources/site/lib/enonic/menu/index.js
+++ b/src/main/resources/site/lib/enonic/menu/index.js
@@ -91,8 +91,8 @@ function menuItemToJson(content, levels) {
         name: content._name,
         id: content._id,
         hasChildren: subMenus.length > 0,
-        children: subMenus,
-        type: content.type
+        type: content.type,
+        children: subMenus
     };
 }
 


### PR DESCRIPTION
When using the util log to output json, we’ll easily miss the new “type” parameter because it is placed after the list of “children”. By moving “type” above “children” we ensure even huge menues get a good log output you can easily overview.