### PR TITLE
Add "aria-current" attr to menu and breadcrumb

### DIFF
--- a/src/main/resources/lib/menu.js
+++ b/src/main/resources/lib/menu.js
@@ -16,6 +16,7 @@ const globals = {
  *   @param {String} [params.homepageTitle=null] - Customize (overwrite) the displayName of home/site link (if used). Common usage: "Home" or "Start".
  *   @param {String} [params.dividerHtml=null] - Any custom html you want appended to each item, except the last one. Common usage: '<span class="divider">/</span>'.
  *   @param {String} [params.urlType=Server] - Control type of URL to be generated for menu items, default is 'server', only other option is 'absolute'.
+ *   @param {String} [params.navigationAriaLabel=null] - The 'aria-label' attribute text on the '<nav>' element. This should be the name of the navigation, e.g "Breadcrumbs".
  * @returns {Object} - The set of breadcrumb menu items (as array) and needed settings.
  */
 exports.getBreadcrumbMenu = function (params = {}) {
@@ -32,6 +33,7 @@ exports.getBreadcrumbMenu = function (params = {}) {
         homepageTitle: params.homepageTitle || null,
         dividerHtml: params.dividerHtml || null,
         urlType: params.urlType == "absolute" ? "absolute" : "server",
+        navigationAriaLabel: params.navigationAriaLabel || null,
     };
 
     // Loop the entire path for current content based on the slashes. Generate one JSON item node for each item.
@@ -92,6 +94,7 @@ exports.getBreadcrumbMenu = function (params = {}) {
 
     // Add divider html (if any) and reverse the menu item array
     breadcrumbMenu.divider = settings.dividerHtml;
+    breadcrumbMenu.navigationAriaLabel = settings.navigationAriaLabel;
     breadcrumbMenu.items = breadcrumbItems.reverse();
 
     return breadcrumbMenu;

--- a/src/main/resources/site/views/fragments/enonic-lib-menu/breadcrumb.html
+++ b/src/main/resources/site/views/fragments/enonic-lib-menu/breadcrumb.html
@@ -1,12 +1,12 @@
-<nav data-th-fragment="breadcrumb" data-th-if="${breadcrumbs}" role="navigation">
+<nav data-th-fragment="breadcrumb" data-th-if="${breadcrumbs}" role="navigation" data-th-aria-label="${breadcrumbs.navigationAriaLabel}">
 	<ol class="breadcrumb-menu">
 		 <li data-th-each="item, iterStat : ${breadcrumbs.items}" data-th-class="
 			  ${item.active ? 'active' : ''} +
 			  ${iterStat.first ? ' first' : ''} +
 			  ${iterStat.last ? ' last' : ''}
 		 ">
-			 <a href="/" data-th-if="${item.url}" data-th-href="${item.url}" data-th-text="${item.title}">Home</a>
-			 <span data-th-unless="${item.url}" data-th-text="${item.title}" data-th-remove="tag">Home</span>
+			 <a href="/" data-th-if="${item.url}" data-th-href="${item.url}" data-th-text="${item.title}" data-th-attr="aria-current=${item.active} ? 'location'">Home</a>
+			 <span data-th-unless="${item.url}" data-th-text="${item.title}" data-th-remove="${!item.active} ? 'tag'" data-th-attr="aria-current=${item.active} ? 'location'">Home</span>
 			 <div data-th-remove="tag" data-th-if="${breadcrumbs.divider} and !${iterStat.last}" data-th-utext="${breadcrumbs.divider}"></div>
 		 </li>
 	</ol>

--- a/src/main/resources/site/views/fragments/enonic-lib-menu/menu.html
+++ b/src/main/resources/site/views/fragments/enonic-lib-menu/menu.html
@@ -8,7 +8,8 @@
 				(menuItem.isActive ? ' active' : '')
 			}">
 			<a href="#" data-th-href="${menuItem.url}"
-				data-th-text="${menuItem.title}" 
+				data-th-text="${menuItem.title}"
+				data-th-attr="aria-current=${menuItem.isActive} ? 'page'"
 				data-th-target="${menuItem.newWindow ? '_blank' : ''}">Page title</a>
 			<ul data-th-if="${menuItem.hasChildren}" class="menu-level-2">
 				<li data-th-each="submenuItem : ${menuItem.children}"
@@ -19,6 +20,7 @@
 					}">
 					<a href="#" data-th-href="${submenuItem.url}"
 						data-th-text="${submenuItem.title}"
+						data-th-attr="aria-current=${submenuItem.isActive} ? 'page'"
 						data-th-target="${submenuItem.newWindow ? '_blank' : ''}">Page title</a>
 					<ul data-th-if="${submenuItem.hasChildren}" class="menu-level-3">
 						<li data-th-each="submenuItem3 : ${submenuItem.children}"
@@ -29,6 +31,7 @@
 							}">
 							<a href="#" data-th-href="${submenuItem3.url}"
 								data-th-text="${submenuItem3.title}"
+								data-th-attr="aria-current=${submenuItem3.isActive} ? 'page'"
 								data-th-target="${submenuItem3.newWindow ? '_blank' : ''}">Page title</a>
 							<ul data-th-if="${submenuItem3.hasChildren}" class="menu-level-4">
 								<li data-th-each="submenuItem4 : ${submenuItem.children}"
@@ -39,6 +42,7 @@
 									}">
 									<a href="#" data-th-href="${submenuItem4.url}"
 										data-th-text="${submenuItem4.title}"
+									  data-th-attr="aria-current=${submenuItem4.isActive} ? 'page'"
 										data-th-target="${submenuItem4.newWindow ? '_blank' : ''}">Page title</a>
 								</li>
 							</ul>


### PR DESCRIPTION
Add `[aria-current="page"]` to the menu item in "menu.html" that has
isActive=true.

Also add `[aria-current="location"]` to the current page in the bread
crumbs menu found in "breadcrumb.html". If `linkActiveItem` is set to
`false` the "&lt;span&gt;" wrapping the active item is not removed, but kept
to hold the "aria-current" attribute.

Screen readers use the "aria-current" attribute to indicate that a page
in a navigation list is the current page the user is visiting.

In "breadcrumb.html" an "aria-label" attribute is set on the "&lt;nav&gt;"
element so that a screen reader can communicate a menu name as a screen
reader user is navigating. The text used in the "aria-label" is
configured with a new param in `getBreadcrumbMenu()"` named
`navigationAriaLabel`.