### PR TITLE
v4 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install this library you need to add a new dependency to your app's `build.gr
 
 ```
 dependencies {
-    include 'com.enonic.lib:lib-menu:3.1.0'
+    include 'com.enonic.lib:lib-menu:4.0.0'
 }
 ```
 
@@ -49,41 +49,57 @@ Check the `/_examples` folder for a few x-datas you can just copy and paste into
 
 In every controller you want to use it (Page, Part or Layout) you just `require` the `/lib/menu` library.
 
-Example:
+To access any of the functions from this library use:
+
 ```javascript
 var libs = {
     menu: require('/lib/menu')
 };
 ```
 
-To access any of the functions from this library use:
-
 <h4>Menu structure</h4>
 
 Get 2 levels of menu based on content setting 'Show in menu'
 ```javascript
-var menuItems = libs.menu.getMenuTree(2); 
+let menuItems = libs.menu.getMenuTree(2); 
 ```
+
+Get 2 levels of menu based on content setting 'Show in menu'
+```javascript
+let menuItems = libs.menu.getMenuTree(2, { content}); 
+```
+
+#### getMenuTree(level, options)
+| Param | default | description |
+| ----- | ------- | ----------- |
+| `levels` | 1 | The number of submenus to retrieve |
+| `options` | {} | Options object |
+| `options.ariaLabel` | "menu" | The aria label for the menu |
+| `options.urlType`|  "server" | Control type of URL to be generated for menu items, default is 'server', only other option is 'absolute' |
+| options.returnContent | false | Controls what info to return 
+| options.query | ""  | Query string to add when searching for menu items
+
 <h4>Breadcrumb structure</h4>
 
 Get a breadcrumb menu for current content. AriaLabel is optional but recommended.
 ```javascript
-var breadcrumbItems = libs.menu.getBreadcrumbMenu({ navigationAriaLabel: "breadcrumbs" }); 
+let breadcrumbItems = libs.menu.getBreadcrumbMenu({ navigationAriaLabel: "breadcrumbs" }); 
 ```
 
 To be more flexible, subMenuItems require a content to be sent in.
 ```javascript
-var content = libs.portal.getContent();
-var subMenuItems = libs.menu.getSubMenus(content,1); // Get 1 level of submenu (from current content)
+const content = libs.portal.getContent();
+let subMenuItems = libs.menu.getSubMenus(content,1); // Get 1 level of submenu (from current content)
 ```
 
 ### Thymeleaf
 
-We've included Thymeleaf fragments you can use for the different types of menues we have. They can be used like this after version `2.0.0` of this lib is installed.
+* We've included Thymeleaf fragments you can use for the different types of menues we have. In `2.0.0` version.
+* In `4.0.0` need to pass in an argument to the fragments.
 
 ```html
-<div data-th-replace="/site/views/fragments/enonic-lib-menu/menu :: main-menu"></div>
-<div data-th-replace="/site/views/fragments/enonic-lib-menu/breadcrumb :: breadcrumb"></div>
+<div data-th-replace="/site/views/fragments/enonic-lib-menu/menu :: main-menu (${menu})"></div>
+<div data-th-replace="/site/views/fragments/enonic-lib-menu/breadcrumb :: breadcrumb(${breadcrumbs})"></div>
 ```
 
 We've also included a bunch of example code of ready-to-go Thymeleaf in the `/_examples/views/` folder, have a look there if you need to build something custom. Also read the readme-files in those folders for more information.
@@ -92,14 +108,10 @@ We've also included a bunch of example code of ready-to-go Thymeleaf in the `/_e
 
 | Lib version        | XP version |
 | ------------- | ------------- |
-| 3.2.0+ | 7.0.0 |
-| 3.0.0 | 7.0.0 |
+| 4.0.0 | 7.0.0 |
+| 3.0.0+ | 7.0.0 |
 | 2.0.0 | 6.13.1 |
-| 1.3.3 | 6.3.0 |
-| 1.3.2 | 6.3.0 |
-| 1.3.1 | 6.3.0 |
-| 1.3.0 | 6.3.0 |
-| 1.2.0 | 6.3.0 |
+| 1.2.0+ | 6.3.0 |
 | 1.1.1 | 6.1.0 |
 | 1.1.0 | 6.1.0 |
 | 1.0.0 | 6.0.0 |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let menuItems = libs.menu.getMenuTree(2);
 
 Get 2 levels of menu based on content setting 'Show in menu'
 ```javascript
-let menuItems = libs.menu.getMenuTree(2, { content}); 
+let menuItems = libs.menu.getMenuTree(2, { returnContent = true }); 
 ```
 
 #### getMenuTree(level, options)
@@ -76,8 +76,8 @@ let menuItems = libs.menu.getMenuTree(2, { content});
 | `options` | {} | Options object |
 | `options.ariaLabel` | "menu" | The aria label for the menu |
 | `options.urlType`|  "server" | Control type of URL to be generated for menu items, default is 'server', only other option is 'absolute' |
-| options.returnContent | false | Controls what info to return 
-| options.query | ""  | Query string to add when searching for menu items
+| `options.returnContent` | false | Controls what info to return 
+| `options.query` | ""  | Query string to add when searching for menu items
 
 <h4>Breadcrumb structure</h4>
 

--- a/_examples/views/example-1level.html
+++ b/_examples/views/example-1level.html
@@ -1,4 +1,4 @@
-<nav data-th-if="${menuItems}" role="navigation">
+<nav data-th-if="${menu}" role="navigation">
 	<ul class="menu-main">
 		<!--/*
 			INFO: Remove the comment around this block to add a "Home" link first in the menu.
@@ -12,7 +12,7 @@
 			</a>
 		</li>
 		*/-->
-		<li data-th-each="menuItem : ${menuItems}"
+		<li data-th-each="menuItem : ${menu.menuItems}"
 			data-th-class="${
 				'page_item' +
 				(menuItem.hasChildren ? ' has-children' : '') +

--- a/_examples/views/example-2level.html
+++ b/_examples/views/example-2level.html
@@ -1,4 +1,4 @@
-<nav data-th-if="${menuItems}" role="navigation">
+<nav data-th-if="${menu}" role="navigation">
 	<ul class="menu-main">
 		<!--/*
 			INFO: Remove the comment around this block to add a "Home" link first in the menu.
@@ -12,7 +12,7 @@
 			</a>
 		</li>
 		*/-->
-		<li data-th-each="menuItem : ${menuItems}"
+		<li data-th-each="menuItem : ${menu.menuItems}"
 			data-th-class="${
 				'page_item' +
 				(menuItem.hasChildren ? ' has-children' : '') +

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@
 group=com.enonic.lib
 projectName=lib-menu
 xpVersion=7.1.0
-version=4.0.0-BETA
+version=4.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 #
 group=com.enonic.lib
 projectName=lib-menu
-xpVersion=7.0.0
-version=3.2.0
+xpVersion=7.1.0
+version=4.0.0-BETA

--- a/src/main/resources/lib/menu.js
+++ b/src/main/resources/lib/menu.js
@@ -110,8 +110,6 @@ exports.getBreadcrumbMenu = function (params = {}) {
  * @returns {String} object.ariaLabel The ariaLabel used for this menu
  */
 exports.getMenuTree = function (levels, params) {
-    if (params.ariaLabel == undefined)
-        params.ariaLabel = "menu";
     const site = libs.portal.getSite();
     let menuItems = [];
     if (site) {
@@ -120,7 +118,7 @@ exports.getMenuTree = function (levels, params) {
     
     return {
         menuItems,
-        ariaLabel: params.ariaLabel,
+        ariaLabel: params.ariaLabel || "menu",
     };
 };
 
@@ -144,10 +142,14 @@ function getSubMenus(parentContent, levels = 1, params = {}) {
         query: params.query ? params.query : "",
     };
 
-    // Fallback to currentContent if there's no content (like in errorHandlers).
-    let currentContent = libs.portal.getContent() || parentContent;
+    let currentContent = libs.portal.getContent();
 
-    return iterateSubMenus(parentContent, levels);
+    // In controllers without content return an empty menu
+    if (currentContent) {
+        return iterateSubMenus(parentContent, levels);
+    } else {
+        return [];
+    }
 
     function iterateSubMenus(parentContent, levels) {
         const subMenus = [];
@@ -190,7 +192,7 @@ function getSubMenus(parentContent, levels = 1, params = {}) {
         // Is the currently viewed content the current menuitem we are processing?
         if (content._path === currentContent._path) {
             isActive = true;
-            inPath = false; // Reset this so an menuitem isn't both in a path and active (makes no sense)
+            inPath = false; // Reset this so an menuitem isn't both in a path and active
         }
 
         const menuItem = content.x[globals.appPath]["menu-item"];
@@ -216,11 +218,8 @@ function getSubMenus(parentContent, levels = 1, params = {}) {
             type: content.type,
             url,
             children: subMenus,
+            content: settings.returnContent ? content : undefined,
         };
-        
-        if (settings.returnContent) {
-            showMenu.content = content;
-        }
 
         return showMenu;
     }

--- a/src/main/resources/lib/menu.js
+++ b/src/main/resources/lib/menu.js
@@ -31,10 +31,15 @@ exports.getBreadcrumbMenu = function (params = {}) {
     };
     
     const site = libs.portal.getSite();
-    const content = libs.portal.getContent() || site; // Fallback to site if there's no content (like in errorHandlers).
+    const content = libs.portal.getContent(); // Fallback to site if there's no content (like in errorHandlers).
 
     const breadcrumbItems = []; // Stores each menu item
     const breadcrumbMenu = {}; // Stores the final JSON sent to Thymeleaf
+
+    //If no content is found return no results
+    if (content == null || content == undefined) {
+        return breadcrumbItems;
+    }
 
     // Loop the entire path for current content based on the slashes. Generate one JSON item node for each item.
     // If on frontpage, skip the path-loop

--- a/src/main/resources/site/views/fragments/enonic-lib-menu/breadcrumb.html
+++ b/src/main/resources/site/views/fragments/enonic-lib-menu/breadcrumb.html
@@ -1,13 +1,22 @@
-<nav data-th-fragment="breadcrumb" data-th-if="${breadcrumbs}" role="navigation" data-th-aria-label="${breadcrumbs.navigationAriaLabel}">
+<nav data-th-fragment="breadcrumb( breadcrumbs )" data-th-if="${breadcrumbs}"
+	data-th-aria-label="${breadcrumbs.ariaLabel}">
 	<ol class="breadcrumb-menu">
-		 <li data-th-each="item, iterStat : ${breadcrumbs.items}" data-th-class="
+		<li data-th-each="item, iterStat : ${breadcrumbs.items}" data-th-class="
 			  ${item.active ? 'active' : ''} +
 			  ${iterStat.first ? ' first' : ''} +
 			  ${iterStat.last ? ' last' : ''}
 		 ">
-			 <a href="/" data-th-if="${item.url}" data-th-href="${item.url}" data-th-text="${item.title}" data-th-attr="aria-current=${item.active} ? 'location'">Home</a>
-			 <span data-th-unless="${item.url}" data-th-text="${item.title}" tabindex="0" data-th-attr="aria-current=${item.active} ? 'location'">Home</span>
-			 <div data-th-remove="tag" data-th-if="${breadcrumbs.divider} and !${iterStat.last}" data-th-utext="${breadcrumbs.divider}"></div>
-		 </li>
+			<a href="/"
+				data-th-if="${item.url}"
+				data-th-href="${item.url}"
+				data-th-text="${item.title}"
+				data-th-attr="aria-current=${item.active} ? 'location'">Home</a>
+			<a data-th-unless="${item.url}"
+				data-th-text="${item.title}"
+				data-th-attr="aria-current=${item.active} ? 'location'">Home</a>
+			<div data-th-remove="tag"
+				data-th-if="${breadcrumbs.divider} and !${iterStat.last}"
+				data-th-utext="${breadcrumbs.divider}"></div>
+		</li>
 	</ol>
 </nav>

--- a/src/main/resources/site/views/fragments/enonic-lib-menu/menu.html
+++ b/src/main/resources/site/views/fragments/enonic-lib-menu/menu.html
@@ -1,6 +1,8 @@
-<nav data-th-fragment="main-menu" data-th-if="${menuItems}" role="navigation">
+<nav data-th-fragment="main-menu(menu)"
+	data-th-if="${menu.menuItems}"
+	data-th-attr="aria-label=${menu.ariaLabel}">
 	<ul class="menu-main">
-		<li data-th-each="menuItem : ${menuItems}"
+		<li data-th-each="menuItem : ${menu.menuItems}"
 			data-th-class="${
 				'page_item' +
 				(menuItem.hasChildren ? ' has-children' : '') +
@@ -42,7 +44,7 @@
 									}">
 									<a href="#" data-th-href="${submenuItem4.url}"
 										data-th-text="${submenuItem4.title}"
-									  data-th-attr="aria-current=${submenuItem4.isActive} ? 'page'"
+										data-th-attr="aria-current=${submenuItem4.isActive} ? 'page'"
 										data-th-target="${submenuItem4.newWindow ? '_blank' : ''}">Page title</a>
 								</li>
 							</ul>


### PR DESCRIPTION
Added option to include content on returned items.
Added option to include your own query when searching items. Default is an empty string
Removed tabindex on breadcrumb active element
Changed returned structure of getMenuTree
getMenuTree includes ariaLabel defaults to "menu"
Changed thymeleaf fragments to include the new structure
Removed some values from the object returned by renderMenuItem replaced by title
Renamed breadcrumbs navigationalAriaLabel to AriaLabel
Changed the default breadcrumb aria label to "breadcrumbs"

Any changes or things that will confuse developers please do tell