### PR TITLE
Bump version to 5.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block to the build-and-publish step listing both `master` and `4.x`, so the release tooling treats both as release branches.
- `gradle.properties` already declares `version=5.0.0-SNAPSHOT`, so no version change is required here.

The companion `4.x` branch was created from the post-release SNAPSHOT commit `eb61b58` (gradle.properties=`4.2.2-SNAPSHOT`) so the XP 7 maintenance line continues there. A separate PR against `4.x` adds the same `releaseBranch:` block so pushes to that branch are recognized as release-branch builds.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a push to `master` is recognized as a release-branch build by the build-and-publish action

🤖 Generated with [Claude Code](https://claude.com/claude-code)