### PR TITLE
Add release-branch CI config for 4.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block listing both `master` and `4.x` to the `build-and-publish` step on the `4.x` workflow.
- Required so pushes to `4.x` are recognized as release-branch builds (the action reads `releaseBranch:` from the branch's own workflow file).
- No version bump, no docgen change, no `versions.json` change — those are master-only per the app-booster reference.

`4.x` was branched from the post-release SNAPSHOT commit `eb61b58` (gradle.properties=`4.2.2-SNAPSHOT`).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a push to `4.x` is recognized as a release-branch build by the build-and-publish action

🤖 Generated with [Claude Code](https://claude.com/claude-code)