### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ dependencies {
 	implementation xplibs.portal
 
 	testImplementation "com.enonic.xp:testing:${xpVersion}"
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly libs.junit.jupiter.engine
+	testRuntimeOnly libs.junit.platform.launcher
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,3 @@
+[libraries]
+junit-jupiter-engine    = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }


### PR DESCRIPTION
Adopts `gradle/libs.versions.toml` as the version-pinning surface for
the repo, in line with neighbouring libs (e.g. `lib-http-client`,
`lib-markdown`) that already use one. Goal is to unify the tree on a
single dep-pinning convention so bulk bumps (XP 8 SNAPSHOTs etc.) can
sed across every repo.

This is a **pin-for-pin** migration — no version bumps.

## Conventions adopted

- Hyphen-separated lowercase keys (`junit-jupiter-engine`).
- Alphabetically sorted within each section.
- `xpVersion` stays in `gradle.properties` (the rest of the toolchain
  expects it there).
- `xplibs.*` accessors are left untouched — they come from the XP
  settings plugin, not this repo's catalog.

## Catalog

```toml
[libraries]
junit-jupiter-engine    = { module = "org.junit.jupiter:junit-jupiter-engine" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
```

## Notes

- The previous `build.gradle` had **no explicit-version inline deps**
  (the grep specified in the migration brief returned 0 hits). The only
  catalogable entries are the two junit refs, which were already
  unversioned (resolved to 6.0.3 via the `com.enonic.xp:testing` BOM).
  We catalog them anyway for accessor consistency and to give future
  bumps a place to land — no `[versions]` block needed yet.
- Resolved `testRuntimeClasspath` is byte-identical to pre-migration;
  junit still resolves to 6.0.3.
- `./gradlew build --refresh-dependencies` is green locally.